### PR TITLE
Don't load on retail

### DIFF
--- a/oUF_ClassicAuraDurations.lua
+++ b/oUF_ClassicAuraDurations.lua
@@ -1,6 +1,8 @@
 local addonName, ns = ...
 local oUF = ns.oUF or oUF
 
+if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then return end
+
 local LibClassicDurations = LibStub("LibClassicDurations")
 LibClassicDurations:RegisterFrame(addonName)
 


### PR DESCRIPTION
Without this LUA errors will pop as LibClassicDurations is not loaded on retail.

(Github web editor added the new line ending at the end)